### PR TITLE
Changed shooting label and icon

### DIFF
--- a/maps/static/config.js
+++ b/maps/static/config.js
@@ -80,7 +80,7 @@ const callTypeConfig = {
     "FD RESCUE": null,
     "FOUND PERSON": null,
     "INDECENT EXPOSURE": null,
-    "SHOOTING": null,
+    "SHOOTING": ["fa-skull-crossbones", death],
     "FD LIFTING ASSISTANCE": null,
     "TRAFFIC CONTROL": trafficConfig,
     "TRAFFIC LIGHT MALFUNCTION": trafficConfig,


### PR DESCRIPTION
The shooting call type now has a death icon, instead of an hazard icon