### PR TITLE
Changed Geocode from Providing City to zipcode

### DIFF
--- a/maps/scraper/geocoder/__init__.py
+++ b/maps/scraper/geocoder/__init__.py
@@ -43,4 +43,4 @@ def geocode_lookup(addresses: [str]) -> dict:
         # Fetch job results
         job_manager.fetch_results()
 
-    return job_manager.address_to_coord
+    return job_manager.address_to_geocode

--- a/maps/scraper/geocoder/jobmanager.py
+++ b/maps/scraper/geocoder/jobmanager.py
@@ -42,14 +42,15 @@ class Result:
         values = list(filter(None, values))
 
         # Set properties in order (result follows heading schema)
-        self.id, self.address, self.city, self.state, self.country, self.lat, self.lon = values
+        # Zipcode will be inaccurate most likely, pls ignore it
+        self.id, self.address, self.zipcode, self.state, self.country, self.lat, self.lon, self.city = values
 
         self.coord = (self.lat, self.lon)
 
 
-def format_address(id_, address, city='Springdale', state='AR', country='US'):
+def format_address(id_, address, zipcode=72764, state='AR', country='US'):
     """ Format geocode request body according to our Geocode Dataflow heading """
-    return f'{id_}|{address}|{city}|{state}|{country}'
+    return f'{id_}|{address}|{zipcode}|{state}|{country}'
 
 
 # ------------------------------ JOB MANAGER ------------------------------
@@ -60,7 +61,7 @@ class JobManager:
         self.completed_url = None
 
         self.results: [Result] = []
-        self.address_to_coord = {}
+        self.address_to_geocode = {}
 
     def create(self, addresses):
         """
@@ -129,5 +130,5 @@ class JobManager:
         for row in rows:
             result = Result(row)
             self.results.append(result)
-            self.address_to_coord[result.address] = result.coord
+            self.address_to_geocode[result.address] = {'coord': result.coord, 'city': result.city}
 

--- a/maps/scraper/geocoder/settings.py
+++ b/maps/scraper/geocoder/settings.py
@@ -23,13 +23,14 @@ class GeocodeDataflow:
         # Define input fields for our geo-coding request
         'Id',
         'GeocodeRequest/Address/AddressLine',  # address
-        'GeocodeRequest/Address/Locality',  # city
+        'GeocodeRequest/Address/PostalCode',  # Zip Code
         'GeocodeRequest/Address/AdminDistrict',  # state
         'GeocodeRequest/Address/CountryRegion',  # country
 
         # Define Response fields latitude and longitude
         'GeocodeResponse/Point/Latitude',
-        'GeocodeResponse/Point/Longitude'
+        'GeocodeResponse/Point/Longitude',
+        'GeocodeResponse/Address/Locality' # City
     )
     # Generate our schema for geo-coding requests and responses to the Dataflow API
     HEADING = 'Bing Spatial Data Services, 2.0\n' + '|'.join(FIELDS)

--- a/maps/scraper/springdale.py
+++ b/maps/scraper/springdale.py
@@ -13,14 +13,16 @@ SPRINGDALE_TZ = pytz.timezone('America/Chicago')
 
 def geocode_calls(calls):
     addresses = [call.address for call in calls]
-    address_to_coord = geocode_lookup(addresses)
+    address_to_geocode = geocode_lookup(addresses)
 
     for call in calls:
         # Lookup the coordinates for the address from our response
-        lat, lon = address_to_coord[call.address]
+        result = address_to_geocode[call.address]
+        lat, lon = result['coord']
 
         call.lat = lat
         call.lon = lon
+        call.city = result['city']
 
     return calls
 


### PR DESCRIPTION
Fixes #13;

Basically, I changed the Geocode Job Manager to provide the zipcode of the city from the city itself. With city, if the address didn't exist in the city, bing maps would just search ALL OF ARKANSAS for the first one it found. 

With zipcode, it searches the nearest it can find to that zipcode. I set the default for springdale to be 72764, which is mid to east Springdale.

I also made a slight change, because Bing Maps will give us the city back, so I hijacked `address_to_coords` (now `address_to_geocode`) to return a dict with both `coords` and `city`. So now city is overwritten with Bing Maps data, which is much more accurate than assuming Springdale for everything.