### PR TITLE
Resolves Bing Maps Errors

### DIFF
--- a/maps/scraper/geocoder/jobmanager.py
+++ b/maps/scraper/geocoder/jobmanager.py
@@ -30,7 +30,7 @@ def request_post(*args, params=None, **kwargs):
         return requests.post(*args, params=params, **kwargs)
     except requests.ConnectionError:
         # See notes in request_get
-        return BingTimeoutError()
+        raise BingTimeoutError()
 
 
 def request_get(*args, params=None, **kwargs):
@@ -41,7 +41,7 @@ def request_get(*args, params=None, **kwargs):
         # Something broke on Bing Maps API end, happens a couple times a month. No worries though, we'll just grab it on the next run
         # Interesting bit is, it usually happens in batches, like 5 in a day, then nothing for a couple weeks, I guess just bing maps outages, or something with our account
         # Problem is always resolved by just trying again later though
-        return BingTimeoutError()
+        raise BingTimeoutError()
 
 
 # ------------------------------ GEO-CODING RESULT CLASS ------------------------------

--- a/maps/scraper/geocoder/jobmanager.py
+++ b/maps/scraper/geocoder/jobmanager.py
@@ -26,12 +26,22 @@ def update_params(params):
 
 def request_post(*args, params=None, **kwargs):
     params = update_params(params)
-    return requests.post(*args, params=params, **kwargs)
+    try:
+        return requests.post(*args, params=params, **kwargs)
+    except requests.ConnectionError:
+        # See notes in request_get
+        return BingTimeoutError()
 
 
 def request_get(*args, params=None, **kwargs):
     params = update_params(params)
-    return requests.get(*args, params=params, **kwargs)
+    try:
+        return requests.get(*args, params=params, **kwargs)
+    except requests.ConnectionError:
+        # Something broke on Bing Maps API end, happens a couple times a month. No worries though, we'll just grab it on the next run
+        # Interesting bit is, it usually happens in batches, like 5 in a day, then nothing for a couple weeks, I guess just bing maps outages, or something with our account
+        # Problem is always resolved by just trying again later though
+        return BingTimeoutError()
 
 
 # ------------------------------ GEO-CODING RESULT CLASS ------------------------------
@@ -140,6 +150,7 @@ class JobManager:
 
         # It is time to download those hot new addresses. Exciting right? Almost as exciting as getting a dell
         results_txt = request_get(self.completed_url).text
+
 
         # Split into list
         rows = results_txt.split('\n')


### PR DESCRIPTION
Basically catches more bing maps errors when they’re not our fault
- Fixes #17
- Fixes CRIME-MAP-12
- Fixes CRIME-MAP-11
- Fixes CRIME-MAP-10

Shouldn't have any effect on what the client sees, but should stop us from getting Sentry emails (and I guess the the job manager will fail more gracefully, and not stop the entire process)