### PR TITLE
Fixed Missing City

### DIFF
--- a/maps/scraper/geocoder/jobmanager.py
+++ b/maps/scraper/geocoder/jobmanager.py
@@ -49,7 +49,9 @@ def request_get(*args, params=None, **kwargs):
 class Result:
     def __init__(self, row):
         # Split line up into list by pipe separator, then remove empty strings
-        values = row.split('|')
+        values = row.replace('\r', '').split('|')
+        if values[2] == '' and values[7] != '':
+            values[2] = values[7]
         values = list(filter(None, values))
 
         # Set properties in order (result follows heading schema)


### PR DESCRIPTION
There was a bug where we'd get a row with the following when using the city search
`49|631 N FOX MEADOWS LN||AR|US|36.0739418375767|-94.2839022275433|Fayetteville`

If you can see, the third item is missing, and it's supposed to be the city input (or the 8th item).

This commit adds a fix to set the third item to the eighth if the third is missing